### PR TITLE
6in4

### DIFF
--- a/fingerprintls/fingerprintls.c
+++ b/fingerprintls/fingerprintls.c
@@ -71,6 +71,7 @@ void print_usage(char *bin_name) {
 	fprintf(stderr, "    -h                This message\n");
 	fprintf(stderr, "    -i <interface>    Sniff packets from specified interface\n");
 	fprintf(stderr, "    -p <pcap file>    Read packets from specified pcap file\n");
+	fprintf(stderr, "    -P <pcap file>    Save packets to specified pcap file for unknown fingerprints\n");
 	fprintf(stderr, "    -j <json file>    Output JSON fingerprints\n");
 	fprintf(stderr, "    -s                Output JSON signatures of unknown connections to stdout\n");
 	fprintf(stderr, "    -d                Show reasons for discarded packets (post BPF)\n");
@@ -91,6 +92,7 @@ int main(int argc, char **argv) {
 	char *unpriv_user = NULL;							/* User for dropping privs */
 	char errbuf[PCAP_ERRBUF_SIZE];				/* error buffer */
 	extern pcap_t *handle;								/* packet capture handle */
+	extern pcap_t *output_handle;					/* output to pcap handle */
 
 	char *filter_exp = default_filter;
 	int arg_start = 1, i;
@@ -130,6 +132,11 @@ int main(int argc, char **argv) {
 				handle = pcap_open_offline(argv[++i], errbuf);
 				printf("Reading from file: %s\n", argv[i]);
 				break;
+			case 'P':
+				/* Open the file */
+				handle = pcap_open_offline(argv[++i], errbuf);
+				printf("Reading from file: %s\n", argv[i]);
+				break;
 			case 'i':
 				/* Open the interface */
 				/* Check if file already successfully opened, if bad filename we can fail to sniffing */
@@ -152,6 +159,7 @@ int main(int argc, char **argv) {
 				/* JSON output to stdout */
 				if((json_fd = fopen("/dev/stdout", "a")) == NULL) {
 					printf("Cannot open JSON file for output\n");
+					fprintf(json_fd, "FD TEST\n");
 					exit(-1);
 				}
 				break;

--- a/fingerprintls/fingerprintls.h
+++ b/fingerprintls/fingerprintls.h
@@ -171,7 +171,7 @@ struct fingerprint_new {
 /* This works perfectly well for TLS, but does not catch horrible SSLv2 packets, soooooo.... */
 //char *default_filter = "tcp[tcp[12]/16*4]=22 and (tcp[tcp[12]/16*4+5]=1) and (tcp[tcp[12]/16*4+9]=3) and (tcp[tcp[12]/16*4+1]=3) and (tcp[tcp[12]/16*4+43]=0)";
 /* Filter should now catch TCP based Client Hello, all IPv6 (because BPF doesn't support v6 Payload... gah!) and Client Hellos wrapped in Teredo tunnels */
-char *default_filter = "(tcp[tcp[12]/16*4]=22 and (tcp[tcp[12]/16*4+5]=1) and (tcp[tcp[12]/16*4+9]=3) and (tcp[tcp[12]/16*4+1]=3)) or (ip6 and tcp) or ((udp[14] = 6 and udp[16] = 32 and udp[17] = 1) and ((udp[(udp[60]/16*4)+48]=22) and (udp[(udp[60]/16*4)+53]=1) and (udp[(udp[60]/16*4)+57]=3) and (udp[(udp[60]/16*4)+49]=3))) or (proto 41 and ip[26] = 6 and ip[(ip[72]/16*4)+60]=22 and (ip[(ip[72]/16*4+5)+60]=1) and (ip[(ip[72]/16*4+9)+60]=3) and (ip[(ip[72]/16*4+1)+60]=3))";
+char *default_filter = "(tcp[tcp[12]/16*4]=22 and (tcp[tcp[12]/16*4+5]=1) and (tcp[tcp[12]/16*4+9]=3) and (tcp[tcp[12]/16*4+1]=3)) or (ip6[(ip6[52]/16*4)+40]=22 and (ip6[(ip6[52]/16*4+5)+40]=1) and (ip6[(ip6[52]/16*4+9)+40]=3) and (ip6[(ip6[52]/16*4+1)+40]=3)) or ((udp[14] = 6 and udp[16] = 32 and udp[17] = 1) and ((udp[(udp[60]/16*4)+48]=22) and (udp[(udp[60]/16*4)+53]=1) and (udp[(udp[60]/16*4)+57]=3) and (udp[(udp[60]/16*4)+49]=3))) or (proto 41 and ip[26] = 6 and ip[(ip[72]/16*4)+60]=22 and (ip[(ip[72]/16*4+5)+60]=1) and (ip[(ip[72]/16*4+9)+60]=3) and (ip[(ip[72]/16*4+1)+60]=3))";
 
 //char *default_filter = "";
 

--- a/fingerprintls/fingerprintls.h
+++ b/fingerprintls/fingerprintls.h
@@ -171,7 +171,7 @@ struct fingerprint_new {
 /* This works perfectly well for TLS, but does not catch horrible SSLv2 packets, soooooo.... */
 //char *default_filter = "tcp[tcp[12]/16*4]=22 and (tcp[tcp[12]/16*4+5]=1) and (tcp[tcp[12]/16*4+9]=3) and (tcp[tcp[12]/16*4+1]=3) and (tcp[tcp[12]/16*4+43]=0)";
 /* Filter should now catch TCP based Client Hello, all IPv6 (because BPF doesn't support v6 Payload... gah!) and Client Hellos wrapped in Teredo tunnels */
-char *default_filter = "(tcp[tcp[12]/16*4]=22 and (tcp[tcp[12]/16*4+5]=1) and (tcp[tcp[12]/16*4+9]=3) and (tcp[tcp[12]/16*4+1]=3)) or (ip6 and tcp) or ((udp[14] = 6 and udp[16] = 32 and udp[17] = 1) and ((udp[(udp[60]/16*4)+48]=22) and (udp[(udp[60]/16*4)+53]=1) and (udp[(udp[60]/16*4)+57]=3) and (udp[(udp[60]/16*4)+49]=3)))";
+char *default_filter = "(tcp[tcp[12]/16*4]=22 and (tcp[tcp[12]/16*4+5]=1) and (tcp[tcp[12]/16*4+9]=3) and (tcp[tcp[12]/16*4+1]=3)) or (ip6 and tcp) or ((udp[14] = 6 and udp[16] = 32 and udp[17] = 1) and ((udp[(udp[60]/16*4)+48]=22) and (udp[(udp[60]/16*4)+53]=1) and (udp[(udp[60]/16*4)+57]=3) and (udp[(udp[60]/16*4)+49]=3))) or (proto 41 and ip[26] = 6 and ip[(ip[72]/16*4)+60]=22 and (ip[(ip[72]/16*4+5)+60]=1) and (ip[(ip[72]/16*4+9)+60]=3) and (ip[(ip[72]/16*4+1)+60]=3))";
 
 //char *default_filter = "";
 
@@ -194,6 +194,15 @@ char *default_filter = "(tcp[tcp[12]/16*4]=22 and (tcp[tcp[12]/16*4+5]=1) and (t
 
   ((udp[(udp[60]/16*4)+48]=22) and (udp[(udp[60]/16*4)+53]=1) and (udp[(udp[60]/16*4)+57]=3) and (udp[(udp[60]/16*4)+49]=3))
 
+
+  proto 41  <--- all of 6in4
+  "proto 41 and ip[26] = 6" <-- tcp header set as next header
+  60 for tcp
+
+(ip[ip[72]/16*4]=22 and (ip[ip[72]/16*4+5]=1) and (ip[ip[72]/16*4+9]=3) and (ip[ip[72]/16*4+1]=3))
+
+"proto 41 and ip[26] = 6 and ip[(ip[72]/16*4)+60]=22 and (ip[(ip[72]/16*4+5)+60]=1) and (ip[(ip[72]/16*4+9)+60]=3) and (ip[(ip[72]/16*4+1)+60]=3)" <--- TLS in 6in4  XXX This technique used in IPv6 filter too plz
+
 */
 
 /* --------- */
@@ -209,6 +218,8 @@ char hostname[HOST_NAME_MAX];			/* store the hostname once to save multiple look
 
 /* These were in main, but this let's the signal handler close as needed */
 pcap_t *handle = NULL;						/* packet capture handle */
+pcap_t *output_handle = NULL;					/* output to pcap handle */
+
 struct bpf_program fp;					/* compiled filter program (expression) */
 /* --------------------------------------------------------------------- */
 

--- a/fingerprintls/packet_processing.c
+++ b/fingerprintls/packet_processing.c
@@ -112,9 +112,7 @@ void got_packet(u_char *args, const struct pcap_pkthdr *pcap_header, const u_cha
 				// XXX Need to research further but seems skipping 8 bytes is all we need?  But how.... hmmmm...
 				//ethernet = (struct ether_header*)(packet + size_vlan_offset + 8);
 
-				// XXX yeah this totally doesn't work yet....  fix this :)
-
-				// XXX oh doh, BPF?!
+				//  This is just a placeholder for now.  BPF will probably need updating.
 				printf("PPPoE\n");
 				break;
 		}
@@ -175,7 +173,7 @@ void got_packet(u_char *args, const struct pcap_pkthdr *pcap_header, const u_cha
 							thus I'm going to assume that is the case for now and set ip_version to 5 (4 to 6 intermediary as I will
 							never have to support actual IPv5).
 						*/
-						ip_version = 5;
+						ip_version = 7;
 
 						udp = (struct udp_header*)(packet + SIZE_ETHERNET + size_vlan_offset + size_ip);
 						teredo = (struct teredo_header*)(udp + 1);  /* +1 is UDP header, not bytes ;) */
@@ -187,7 +185,7 @@ void got_packet(u_char *args, const struct pcap_pkthdr *pcap_header, const u_cha
 
 					case 0x29:
 						/* Not using this yet, but here ready for when I impliment 6in4 de-encapsultion (per teredo) */
-						ip_version = 9;  // No reason... YOLO
+						ip_version = 8;  // No reason... YOLO
 						ipv6 = (struct ip6_hdr*)(packet + SIZE_ETHERNET + size_vlan_offset + sizeof(struct ipv4_header));
 
 						// OK This works ok
@@ -230,7 +228,7 @@ void got_packet(u_char *args, const struct pcap_pkthdr *pcap_header, const u_cha
 				tcp = (struct tcp_header*)(packet + SIZE_ETHERNET + size_vlan_offset + size_ip);
 				payload = (u_char *)(packet + SIZE_ETHERNET + size_vlan_offset + size_ip + (tcp->th_off * 4));
 				// Emulating: "(tcp[tcp[12]/16*4]=22 and (tcp[tcp[12]/16*4+5]=1) and (tcp[tcp[12]/16*4+9]=3) and (tcp[tcp[12]/16*4+1]=3))"
-				if(!(payload[0] == 22 && payload[5] == 1 && payload[9] == 3 && payload[1] == 3))
+				//if(!(payload[0] == 22 && payload[5] == 1 && payload[9] == 3 && payload[1] == 3))
 					return; /* Doesn't match our not BPF, BPF.... BAILING OUT!! */
 
 
@@ -326,7 +324,7 @@ void got_packet(u_char *args, const struct pcap_pkthdr *pcap_header, const u_cha
 		/* ID and Desc (with defaults for unknown fingerprints) */
 		fp_packet->fingerprint_id = 0;
 		switch(ip_version) {
-			case 5:
+			case 7:
 				/* Temporarily Doing this to PoC teredo.  Will use outer and inner once it's working */
 				/* IPv4 source and IPv6 dest is sorta what the connection is, so temping with that */
 				inet_ntop(AF_INET,(void*)&ipv4->ip_src,src_address_buffer,sizeof(src_address_buffer));
@@ -340,7 +338,7 @@ void got_packet(u_char *args, const struct pcap_pkthdr *pcap_header, const u_cha
 				inet_ntop(af_type,(void*)&ipv6->ip6_src,src_address_buffer,sizeof(src_address_buffer));
 				inet_ntop(af_type,(void*)&ipv6->ip6_dst,dst_address_buffer,sizeof(dst_address_buffer));
 				break;
-			case 9:
+			case 8:
 				inet_ntop(AF_INET,(void*)&ipv4->ip_src,src_address_buffer,sizeof(src_address_buffer));
 				inet_ntop(AF_INET6,(void*)&ipv6->ip6_dst,dst_address_buffer,sizeof(dst_address_buffer));
 		}


### PR DESCRIPTION
- 6in4 support added (assuming standard headers, etc).
- Updated BPF for native ipv6 to pre-filter for TLS client hello packets as per ipv4, teredo and 6in4.  Initially didn't as BPF doesn't support "ip6 and tcp[xx]" type notation, but I have since clued in that it _does_ support ip6[xx] notation and I manually calculated the offsets.
