### PR TITLE
Changes to compile and run cleanly on OpenBSD 6.0-CURRENT.

### DIFF
--- a/fingerprintls/fingerprintls.c
+++ b/fingerprintls/fingerprintls.c
@@ -14,7 +14,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+along with FingerprinTLS.  If not, see <http://www.gnu.org/licenses/>.
 
 Exciting Licence Info Addendum.....
 
@@ -41,7 +41,12 @@ mistakes, kthnxbai.
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <unistd.h>
+#if defined(__OpenBSD__)
+#include <net/if_arp.h>
+#include <netinet/if_ether.h>
+#else
 #include <net/ethernet.h>
+#endif
 #include <netinet/ip6.h>
 #include <grp.h>
 
@@ -410,10 +415,9 @@ int main(int argc, char **argv) {
 		    filter_exp, pcap_geterr(handle));
 		exit(EXIT_FAILURE);
 	}
-
 	/* setup hostname variable for use in logs (incase of multiple hosts) */
 	if(gethostname(hostname, HOST_NAME_MAX) != 0) {
-		sprintf(hostname, "unknown");
+		snprintf(hostname, sizeof("unknown"), "unknown");
 	}
 
 	/* now we can set our callback function */

--- a/fingerprintls/fingerprintls.h
+++ b/fingerprintls/fingerprintls.h
@@ -14,7 +14,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+along with FingerprinTLS.  If not, see <http://www.gnu.org/licenses/>.
 
 Exciting Licence Info Addendum.....
 
@@ -177,7 +177,14 @@ struct fingerprint_new {
 /* Filter should now catch TCP based Client Hello, all IPv6 (because BPF doesn't support v6 Payload... gah!) and Client Hellos wrapped in Teredo tunnels */
 
 // XXX CHECK IPv6.... doesn't seem to work properly for Chrome testing time!!
+// Using terrible ifdefs here to avoid needing to try to figure out the root cause of the OpenBSD errors with simple filters.
+// Without this, execution on OpenBSD throws: Couldn't parse filter <outputs the filter string here>: too many registers needed to evaluate expression
+// Short filters sometimes work and sometimes don't, seems like some sort of weird complexity issue.
+#if defined(__OpenBSD__)
+char *default_filter = "";
+#else
 char *default_filter = "(tcp[tcp[12]/16*4]=22 and (tcp[tcp[12]/16*4+5]=1) and (tcp[tcp[12]/16*4+9]=3) and (tcp[tcp[12]/16*4+1]=3)) or (ip6[(ip6[52]/16*4)+40]=22 and (ip6[(ip6[52]/16*4+5)+40]=1) and (ip6[(ip6[52]/16*4+9)+40]=3) and (ip6[(ip6[52]/16*4+1)+40]=3)) or ((udp[14] = 6 and udp[16] = 32 and udp[17] = 1) and ((udp[(udp[60]/16*4)+48]=22) and (udp[(udp[60]/16*4)+53]=1) and (udp[(udp[60]/16*4)+57]=3) and (udp[(udp[60]/16*4)+49]=3))) or (proto 41 and ip[26] = 6 and ip[(ip[72]/16*4)+60]=22 and (ip[(ip[72]/16*4+5)+60]=1) and (ip[(ip[72]/16*4+9)+60]=3) and (ip[(ip[72]/16*4+1)+60]=3))";
+#endif
 
 //char *default_filter = "";
 

--- a/fingerprintls/packet_processing.c
+++ b/fingerprintls/packet_processing.c
@@ -14,7 +14,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+along with FingerprinTLS.  If not, see <http://www.gnu.org/licenses/>.
 
 Exciting Licence Info Addendum.....
 
@@ -103,8 +103,9 @@ void got_packet(u_char *args, const struct pcap_pkthdr *pcap_header, const u_cha
 			header, however I am keeping it here incase we derive it from somewhere
 			else in future and we want it early in the process.
 		*/
-
-		packet_time = pcap_header->ts;
+		/* Copy each field separately to account for systems where these use different field sizes (OpenBSD...) */
+		packet_time.tv_sec = pcap_header->ts.tv_sec;
+		packet_time.tv_usec = pcap_header->ts.tv_usec;
 		print_time = localtime(&packet_time.tv_sec);
 		if (print_time == NULL) {
 			/* If we get a bad timestamp, set to X's for now, probably just drop in future..... thanks Parker!! ;) */
@@ -115,7 +116,6 @@ void got_packet(u_char *args, const struct pcap_pkthdr *pcap_header, const u_cha
 		} else {
 			strftime(printable_time, sizeof printable_time, "%Y-%m-%d %H:%M:%S", print_time);
 		}
-
 		if(pcap_header->len != pcap_header->caplen) {
 			/* This is most likely something bad, and likely non-fingerprintable anyway */
 			if (show_drops)
@@ -709,9 +709,9 @@ void got_packet(u_char *args, const struct pcap_pkthdr *pcap_header, const u_cha
 			}
 			/* Makes it easier to find dynamic signatures in logs after a daemon restart */
 			if(getpid() < 99999) {
-				sprintf(fp_packet->desc, "Dynamic %s %d %d", hostname, getpid(), newsig_count);
+				snprintf(fp_packet->desc, fp_packet->desc_length, "Dynamic %s %d %d", hostname, getpid(), newsig_count);
 			} else {
-				sprintf(fp_packet->desc, "Dynamic %s %d", hostname, newsig_count);
+				snprintf(fp_packet->desc, fp_packet->desc_length, "Dynamic %s %d", hostname, newsig_count);
 			}
 
 			fp_packet->sig_alg = malloc(fp_packet->sig_alg_length);

--- a/fingerprintls/signal.c
+++ b/fingerprintls/signal.c
@@ -14,7 +14,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+along with FingerprinTLS.  If not, see <http://www.gnu.org/licenses/>.
 
 Exciting Licence Info Addendum.....
 


### PR DESCRIPTION
Lots of little things. As noted, all of those ifdefs should really be checking for the actual feature, not just the OS, but that requires autoconf and I don't want to.

Never did figure out the filter issue, so it just gets set permissive on OpenBSD.